### PR TITLE
feat: introduce JSON output mode for depup scan

### DIFF
--- a/src/depup/utils/scan_utils.py
+++ b/src/depup/utils/scan_utils.py
@@ -1,0 +1,21 @@
+def _convert_to_jsonable(deps, infos):
+    info_by_name = {i.name.lower(): i for i in infos}
+
+    items = []
+    for dep in deps:
+        info = info_by_name.get(dep.name.lower())
+
+        items.append({
+            "name": dep.name,
+            "declared": dep.version,
+            "current": dep.version,  # for env mode declared=None
+            "latest": info.latest if info else None,
+            "update_type": info.update_type if info else "none",
+            "source": dep.source_file.name if dep.source_file else None,
+        })
+    return items
+
+
+__all__ = [
+    "_convert_to_jsonable",
+]


### PR DESCRIPTION
### Summary

This PR introduces JSON output support to the `depup scan` command, enabling
machine-readable results for CI pipelines, reports, and integrations with
external tools.

### Key Features

#### New `--json` flag
You can now run:

```bash
depup scan --json
depup scan --latest --json
depup scan --env --json
depup scan --env --latest --json
````

The command emits structured JSON to stdout instead of rendering Rich tables.

#### Unified JSON Schema

Each dependency record includes:

```json
{
  "name": "<package>",
  "declared": "<specifier or null>",
  "current": "<current version>",
  "latest": "<latest version or null>",
  "update_type": "none | patch | minor | major",
  "source": "pyproject.toml | requirements.txt | Pipfile | null"
}
```

This schema works consistently for both file-based and environment-based scans.

#### CI-friendly

This feature is foundational for:

* automated pipelines
* PR bots
* markdown report generation
* the upcoming `--check` mode

#### 🔧 Internal Enhancements

* Added `_convert_to_jsonable()` helper for clean JSON formatting
* JSON mode bypasses Rich UI rendering for clarity and machine consumption
* Integrated seamlessly with optimized VersionScanner and EnvironmentScanner

### Why this matters

JSON output is a foundational step toward professional automation support.
`depup` now becomes viable for:

* GitHub Actions workflows
* Pre-commit hooks
* Automated dependency dashboards
* PR-level reporting

This dramatically increases its usefulness and adoption potential.