### PR TITLE
feat(scan): add read-only Pipfile.lock support

### DIFF
--- a/src/depup/cli/main.py
+++ b/src/depup/cli/main.py
@@ -14,6 +14,7 @@ from depup.core.upgrade_executor import UpgradeExecutor, PlannedUpgrade
 from depup.core.environment_scanner import EnvironmentScanner
 from depup.core.models import VersionInfo
 from depup.core.poetry_lock_parser import PoetryLockParser
+from depup.core.pipfile_lock_parser import PipfileLockParser
 from depup.utils.render import *
 from depup.utils.upgrade_utils import *
 from depup.utils.scan_utils import *
@@ -129,11 +130,17 @@ def scan_command(
     parser = DependencyParser(project_root)
     deps = parser.parse_all()
 
+    # Poetry lockfile (read-only)
     poetry_parser = PoetryLockParser(project_root)
     poetry_deps = poetry_parser.parse()
-
     if poetry_deps:
         deps.extend(poetry_deps)
+
+    # Pipfile.lock (read-only)
+    pipfile_parser = PipfileLockParser(project_root)
+    pipfile_deps = pipfile_parser.parse()
+    if pipfile_deps:
+        deps.extend(pipfile_deps)
 
     if not deps:
         console.print(

--- a/src/depup/core/pipfile_lock_parser.py
+++ b/src/depup/core/pipfile_lock_parser.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+from depup.core.models import DependencySpec
+
+
+class PipfileLockParser:
+    """Read-only parser for Pipfile.lock."""
+
+    LOCKFILE_NAME = "Pipfile.lock"
+
+    def __init__(self, project_root: Path) -> None:
+        self.project_root = project_root
+        self.lockfile_path = project_root / self.LOCKFILE_NAME
+
+    def exists(self) -> bool:
+        return self.lockfile_path.exists()
+
+    def parse(self) -> List[DependencySpec]:
+        if not self.exists():
+            return []
+
+        with self.lockfile_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        deps: List[DependencySpec] = []
+
+        for section in ("default", "develop"):
+            packages = data.get(section, {})
+            for name, meta in packages.items():
+                version = meta.get("version")
+                if not version:
+                    continue
+
+                deps.append(
+                    DependencySpec(
+                        name=name,
+                        version=version,
+                        source_file=self.lockfile_path,
+                    )
+                )
+
+        return deps


### PR DESCRIPTION
## What’s new

This PR adds **read-only support for `Pipfile.lock`** to the `depup scan` command.

### Key features
- Automatically detects and parses `Pipfile.lock`
- Extracts locked dependency versions from:
  - `default`
  - `develop`
- Compares locked versions against latest PyPI releases
- Fully compatible with:
  - `--latest`
  - `--json`
  - `--check`
  - existing file-based scans
- Works alongside `pyproject.toml` and `poetry.lock`

### Why this matters
- Enables depup usage in Pipenv-managed projects
- Completes lockfile coverage for major Python workflows
- Improves CI and automation adoption
- Safe, non-invasive implementation (read-only)

### Design notes
- No dependency on pipenv CLI
- No lockfile rewriting
- Uses existing `DependencySpec` and version scanning pipeline
- Transparent behavior when multiple dependency sources are present

### Examples
```bash
depup scan
depup scan --latest
depup scan --latest --check
depup scan --latest --json
