### PR TITLE
feat(scan): add markdown report generation support

### DIFF
--- a/src/depup/cli/main.py
+++ b/src/depup/cli/main.py
@@ -15,6 +15,7 @@ from depup.core.environment_scanner import EnvironmentScanner
 from depup.core.models import VersionInfo
 from depup.core.poetry_lock_parser import PoetryLockParser
 from depup.core.pipfile_lock_parser import PipfileLockParser
+from depup.utils.report_utils import generate_markdown_report
 from depup.utils.render import *
 from depup.utils.upgrade_utils import *
 from depup.utils.scan_utils import *
@@ -65,6 +66,11 @@ def scan_command(
         "--check",
         help="Exit with non-zero status if outdated dependencies are found.",
     ),
+    report: Optional[Path] = typer.Option(
+        None,
+        "--report",
+        help="Write scan results to a Markdown report file.",
+    ),
 ) -> None:
     """
     Scan dependency files or installed environment for outdated dependencies.
@@ -114,6 +120,15 @@ def scan_command(
                 _render_latest_env_table(deps, infos)
             else:
                 _render_env_table(deps)
+
+        if report:
+            generate_markdown_report(
+                output_path=report,
+                deps=deps,
+                infos=infos,
+                title="Environment Dependency Report",
+            )
+            console.print(f"[green]Markdown report written to {report}[/green]")
 
         # CHECK MODE
         if check:
@@ -177,6 +192,15 @@ def scan_command(
             _render_latest_file_table(deps, infos)
         else:
             _render_declared_file_table(deps)
+
+    if report:
+        generate_markdown_report(
+            output_path=report,
+            deps=deps,
+            infos=infos,
+            title="Project Dependency Report",
+        )
+        console.print(f"[green]Markdown report written to {report}[/green]")
 
     # CHECK MODE
     if check:

--- a/src/depup/utils/report_utils.py
+++ b/src/depup/utils/report_utils.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from depup.core.models import DependencySpec, VersionInfo
+
+
+def generate_markdown_report(
+    output_path: Path,
+    deps: List[DependencySpec],
+    infos: List[VersionInfo],
+    title: str = "Dependency Report",
+) -> None:
+    """
+    Generate a Markdown dependency report.
+    """
+
+    info_by_name = {i.name.lower(): i for i in infos}
+
+    lines: list[str] = []
+    lines.append(f"# {title}\n")
+    lines.append("| Package | Current | Latest | Update Type | Source |")
+    lines.append("|--------|---------|--------|-------------|--------|")
+
+    for dep in deps:
+        info = info_by_name.get(dep.name.lower())
+
+        current = dep.version or ""
+        latest = info.latest if info else ""
+        update_type = info.update_type if info else "none"
+        source = dep.source_file.name
+
+        lines.append(
+            f"| {dep.name} | {current} | {latest} | {update_type} | {source} |"
+        )
+
+    output_path.write_text("\n".join(lines), encoding="utf-8")


### PR DESCRIPTION
## What’s new

This PR introduces **Markdown report generation** for dependency scans via a new `--report` option.

### Key features
- Generates a Markdown report file summarizing dependency status
- Includes:
  - package name
  - current version
  - latest version
  - update type (major/minor/patch/none)
  - source file (pyproject.toml, poetry.lock, Pipfile.lock, env)
- Fully compatible with:
  - `--latest`
  - `--env`
  - `--json`
  - `--check`
  - lockfile scanning (Poetry & Pipenv)

### Why this matters
- Enables easy sharing of dependency status in pull requests
- Makes depup outputs CI- and review-friendly
- Improves usability for teams and automation workflows
- Adds professional polish expected from modern developer tooling

### Design notes
- Markdown generation is implemented as a separate utility
- No changes to core scanning or upgrade logic
- No side effects unless `--report` is explicitly provided

### Examples
```bash
depup scan --latest --report deps.md
depup scan --latest --check --report deps.md
depup scan --env --latest --report env.md
