### PR TITLE
docs: add complete v0.9.0 documentation and GitHub Pages setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,141 +3,301 @@
 [![PyPI Version](https://img.shields.io/pypi/v/depup.svg)](https://pypi.org/project/depup/)
 ![Python Versions](https://img.shields.io/pypi/pyversions/depup.svg)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
-[![Docs](https://img.shields.io/badge/docs-coming--soon-blue)](https://example.com)
-![CI](https://github.com/saran-damm/depup/actions/workflows/ci.yml/badge.svg)
-![Publish](https://github.com/saran-damm/depup/actions/workflows/publish.yml/badge.svg)
+[![CI](https://github.com/saran-damm/depup/actions/workflows/ci.yml/badge.svg)](https://github.com/saran-damm/depup/actions)
+[![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://saran-damm.github.io/depup/)
 
-**Depup** is a modern Python CLI tool that helps developers keep their project dependencies up-to-date, safe, and maintainable. It automatically:
+**depup** is a production-grade Python CLI that helps developers **understand, audit, and safely upgrade dependencies** across projects and environments.
 
-- Scans for declared dependencies  
-- Detects updates on PyPI  
-- Classifies semantic versioning impact (patch/minor/major)  
-- Prepares upgrade paths  
-- (Future) Provides AI-assisted upgrade analysis and code fixes
-
-This tool is built for modern development workflows and future integration with AI agents (Cursor, Windsurf, Continue) via MCP.
+It focuses on:
+- correctness
+- visibility
+- CI-friendliness
+- minimal surprises
 
 ---
 
-## 🚀 Features
 
-### ✅ Current Features
-- Parse `requirements.txt`, `pyproject.toml`, and `Pipfile`
-- Display declared package versions
-- Fetch latest versions from PyPI (`depup scan --latest`)
-- Categorize updates by semantic version (patch/minor/major)
-- Clean, colorized CLI output via Typer + Rich
+## Why Depup?
 
-### 🧭 Roadmap (Planned)
-- Automated safe upgrades via `depup upgrade`
-- Dependency file rewriting after upgrades
-- Post-upgrade code scanning
-- Markdown/HTML upgrade reports
-- LLM-powered changelog summarization
-- MCP Agent integration for AI IDEs
+Managing Python dependencies looks simple—until it isn’t.
+
+Most teams eventually face at least one of these problems:
+
+* Dependencies silently drift out of date
+* Upgrading one package breaks others
+* CI pipelines fail due to incompatible versions
+* Security fixes are delayed because upgrades feel risky
+* Different projects use different dependency formats
+* There’s no clear visibility into *what* will change before upgrading
+
+Depup exists to **make dependency upgrades safe, visible, and intentional**.
+
+---
+
+### The Problem with Existing Tools
+
+| Tool                        | Limitation                             |
+| --------------------------- | -------------------------------------- |
+| `pip list --outdated`       | No semantic context, no safety         |
+| `pip-tools / poetry update` | Updates blindly, often breaking things |
+| Dependabot                  | Reactive, PR-heavy, noisy              |
+| Manual upgrades             | Time-consuming, error-prone            |
+
+Most tools answer **“what is outdated?”**
+Depup answers **“what should I upgrade, why, and how risky is it?”**
+
+---
+
+### What Depup Does Differently?
+
+Depup is designed as a **dependency intelligence layer**, not just an updater.
+
+#### Deep Visibility Before Change
+
+* See **declared vs latest versions**
+* Understand **semantic impact** (patch / minor / major)
+* Works across:
+
+  * `requirements.txt`
+  * `pyproject.toml` (PEP 621 + Poetry)
+  * `Pipfile`
+  * `Poetry.lock`, `Pipfile.lock`
+  * Installed environments (`--env`)
+
+#### Safety-First Upgrades
+
+* Dry-run support (`--dry-run`)
+* Selective upgrades (`--only-patch`, `--only-minor`, `--only-major`)
+* Package-level filtering
+* No blind rewriting of dependency files
+
+#### CI & Automation Ready
+
+* `--check` mode with proper exit codes
+* JSON output for pipelines
+* Markdown reports for audits and reviews
+* Designed for GitHub Actions, GitLab CI, Azure DevOps
+
+#### Built for AI-Native Workflows
+
+Depup is architected to integrate with:
+
+* AI IDE agents (Cursor, Windsurf, Continue)
+* MCP-based tooling
+* Future AI-driven upgrade analysis and code fixes
+
+This makes depup **future-proof**, not just useful today.
+
+---
+
+### Where Depup Fits in Your Workflow
+
+```mermaid
+flowchart LR
+    Dev[Developer / CI]
+    Scan[depup scan]
+    Analyze[Version Analysis]
+    Plan[Upgrade Plan]
+    Upgrade[depup upgrade]
+    Report[JSON / Markdown Reports]
+
+    Dev --> Scan
+    Scan --> Analyze
+    Analyze --> Plan
+    Plan --> Upgrade
+    Plan --> Report
+```
+
+Depup fits **before** upgrades — exactly where most failures happen.
+
+---
+
+### Who depup is for?
+
+* **Individual developers** who want safer upgrades
+* **Teams** managing multiple Python projects
+* **CI/CD pipelines** that need deterministic dependency checks
+* **Open-source maintainers** avoiding breaking releases
+* **AI-assisted workflows** needing structured dependency data
+
+
+---
+
+## Features
+
+### Implemented (v0.9.0)
+- Scan dependency files:
+  - `requirements.txt`
+  - `pyproject.toml` (PEP 621 + Poetry)
+  - `Pipfile`
+  - `Poetry.lock` (read-only)
+  - `Pipfile.lock` (read-only)
+- Scan installed environments (`--env`)
+- Fetch latest versions from PyPI
+- Semantic update classification:
+  - patch / minor / major / none
+- JSON output (`--json`)
+- Markdown reports (`--report`)
+- CI-friendly check mode (`--check`)
+- Deterministic upgrade planning
+- Safe upgrade execution (`depup upgrade`)
+
+### Planned (towards v1.0.0)
+- Smarter conflict detection
+- Editable upgrade policies
+- AI-assisted changelog summaries
+- IDE / MCP agent integration
 
 ---
 
 ## Installation
 
-``` bash
+```bash
 pip install depup
 ```
 
-Or with `uv`:
+or with `uv`:
 
 ```bash
 uv tool install depup
 ```
+
 ---
 
-## 📘 Usage
+## Usage
 
-### List declared dependencies
+### Scan project dependencies
 
 ```bash
 depup scan
 ```
 
-### Show latest available versions from PyPI
+### Include latest versions from PyPI
 
 ```bash
 depup scan --latest
 ```
 
-Example output:
+### Fail CI if outdated dependencies exist
 
+```bash
+depup scan --latest --check
 ```
-┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
-┃ Package Name ┃ Declared Spec┃ Latest Version┃ Update Type  ┃ Source File  ┃
-┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
-│ typer        │ >=0.12       │ 0.12.3        │ patch        │ pyproject.toml
-│ packaging    │ >=24.0       │ 24.1.0        │ patch        │ pyproject.toml
-│ rich         │ >=13.0       │ 13.7.1        │ patch        │ pyproject.toml
-└──────────────┴──────────────┴───────────────┴──────────────┴──────────────┘
+
+### Scan installed environment
+
+```bash
+depup scan --env --latest
+```
+
+### Generate JSON output
+
+```bash
+depup scan --latest --json
+```
+
+### Generate Markdown report
+
+```bash
+depup scan --latest --report deps.md
 ```
 
 ---
 
-## 📂 Supported Dependency Files
+## Upgrading dependencies
 
-* `requirements.txt`
-* `pyproject.toml` (PEP 621 and Poetry)
-* `Pipfile`
+Preview upgrades (safe):
+
+```bash
+depup upgrade --dry-run
+```
+
+Apply upgrades:
+
+```bash
+depup upgrade
+```
+
+Upgrade only patch updates:
+
+```bash
+depup upgrade --only-patch
+```
+
+Upgrade environment packages:
+
+```bash
+depup upgrade --env
+```
 
 ---
 
-## 🧪 Testing
+## Architecture
+
+```mermaid
+flowchart LR
+    CLI[CLI -Typer]
+    Parser[Dependency Parsers]
+    Env[Environment Scanner]
+    Scanner[Version Scanner]
+    Planner[Upgrade Planner]
+    Executor[Upgrade Executor]
+    Reports[Reports / JSON / Markdown]
+
+    CLI --> Parser
+    CLI --> Env
+    Parser --> Scanner
+    Env --> Scanner
+    Scanner --> Planner
+    Planner --> Executor
+    Planner --> Reports
+```
+
+---
+
+## Testing
 
 ```bash
 pytest -q
 ```
 
----
-
-## 🧱 Project Structure
-
-```text
-src/depup/
-    cli/
-    core/
-    reporting/
-    scanning/
-    utils/
-tests/
-pyproject.toml
-README.md
-CHANGELOG.md
-LICENSE
-```
+All critical components are unit tested.
 
 ---
 
-## 🔖 Version Management
+## Versioning Philosophy
 
-We use **bump2version** to automate versioning:
-
-```bash
-bump2version patch  # 0.1.1 → 0.1.2
-bump2version minor  # 0.1.1 → 0.2.0
-bump2version major  # 0.1.1 → 1.0.0
-```
+* `0.x` → Rapid iteration, APIs may evolve
+* `0.9.x` → Feature-complete, stable, CI-ready
+* `1.0.0` → API freeze, backward compatibility guarantees
 
 ---
 
-## 📄 License
+## License
 
-This project is licensed under the MIT License — see the `LICENSE` file for details.
-
----
-
-## 🤝 Contributing
-
-Contributions are welcome!
-Feel free to open issues or submit PRs.
+MIT License — see `LICENSE`.
 
 ---
 
-## ⭐ Acknowledgements
+## Contributing
 
-This project is inspired by modern dependency management workflows and the architecture outlined in the technical design document.
+Issues, PRs, and discussions are welcome.
+Please keep changes small and well-tested.
+
+---
+
+## Acknowledgements
+
+Built with:
+
+* Typer
+* Rich
+* packaging
+* requests
+
+Inspired by real-world CI and dependency pain.
+
+---
+
+## Detailed documentation available at:
+https://saran-damm.github.io/depup/

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,55 @@
+# Architecture Overview
+
+depup is designed as a modular, extensible CLI tool.
+
+---
+
+## High-level architecture
+
+```mermaid
+flowchart LR
+    CLI[depup CLI]
+    Parser[Dependency Parsers]
+    Scanner[Version Scanner]
+    PyPI[PyPI API]
+    Executor[Upgrade Executor]
+    Reports[Reports]
+
+    CLI --> Parser
+    Parser --> Scanner
+    Scanner --> PyPI
+    Scanner --> CLI
+    CLI --> Executor
+    Executor --> Reports
+```
+
+---
+
+## Core components
+
+### CLI Layer
+
+* Typer-based interface
+* Handles flags, output, and exit codes
+
+### Parsers
+
+* Parse dependency declarations and lockfiles
+* Normalize dependencies into a common model
+
+### Version Scanner
+
+* Queries PyPI
+* Compares versions
+* Classifies update impact
+
+### Upgrade Executor
+
+* Applies upgrades safely
+* Updates dependency files
+
+### Reporting
+
+* JSON output
+* Markdown reports
+* CI-friendly results

--- a/docs/ci/github-actions.md
+++ b/docs/ci/github-actions.md
@@ -1,0 +1,67 @@
+# Using depup in GitHub Actions
+
+depup is designed to integrate cleanly into CI pipelines.
+
+---
+
+## Why use depup in CI?
+
+- Prevent outdated dependencies from silently accumulating
+- Enforce dependency hygiene before merge
+- Fail builds when upgrades are required
+
+---
+
+## Basic CI Example
+
+```yaml
+name: Dependency Check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  depup-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install depup
+        run: pip install depup
+
+      - name: Run dependency check
+        run: depup scan --latest --check
+```
+
+---
+
+## Behavior
+
+* Exit code `0` → dependencies OK
+* Exit code `1` → outdated dependencies detected
+* Exit code `2` → invalid usage
+
+---
+
+## JSON-based enforcement
+
+```yaml
+- name: Scan dependencies (JSON)
+  run: depup scan --latest --json --check
+```
+
+Use JSON output if you plan to parse results later.
+
+---
+
+## Recommended practice
+
+* Use `scan --latest --check` on PRs
+* Use `upgrade --dry-run` on release branches

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -1,0 +1,51 @@
+# depup scan
+
+Scan dependencies and detect outdated packages.
+
+---
+
+## What it does
+
+- Reads dependency declarations and lockfiles
+- Optionally checks latest versions on PyPI
+- Produces human-readable or machine-readable output
+
+---
+
+## Command syntax
+
+```bash
+depup scan [PATH] [OPTIONS]
+```
+
+---
+
+## Options
+
+| Option            | Description                          |
+| ----------------- | ------------------------------------ |
+| `--latest`        | Fetch latest versions from PyPI      |
+| `--env`           | Scan installed environment           |
+| `--json`          | Output JSON                          |
+| `--report <file>` | Write Markdown report                |
+| `--check`         | Exit non-zero if outdated deps found |
+
+---
+
+## Examples
+
+```bash
+depup scan --latest
+depup scan --env --latest
+depup scan --latest --check
+```
+
+---
+
+## Exit Codes
+
+| Code | Meaning                            |
+| ---- | ---------------------------------- |
+| 0    | Success / no outdated dependencies |
+| 1    | Outdated dependencies found        |
+| 2    | Invalid flag combination           |

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -1,0 +1,43 @@
+# depup upgrade
+
+Upgrade outdated dependencies safely.
+
+---
+
+## What it does
+
+- Detects outdated dependencies
+- Applies upgrades selectively
+- Updates dependency files
+- Supports dry-run mode
+
+---
+
+## Command syntax
+
+```bash
+depup upgrade [PATH] [PACKAGES...] [OPTIONS]
+```
+
+---
+
+## Options
+
+| Option         | Description                  |
+| -------------- | ---------------------------- |
+| `--only-patch` | Upgrade patch versions only  |
+| `--only-minor` | Upgrade minor versions only  |
+| `--only-major` | Upgrade major versions only  |
+| `--dry-run`    | Show planned upgrades only   |
+| `--yes`        | Skip confirmation            |
+| `--env`        | Upgrade environment packages |
+
+---
+
+## Examples
+
+```bash
+depup upgrade --dry-run
+depup upgrade requests rich
+depup upgrade --env --only-patch
+```

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -1,0 +1,22 @@
+# Exit Codes
+
+depup uses consistent exit codes for CI automation.
+
+---
+
+## Scan command
+
+| Code | Meaning |
+|----|--------|
+| 0 | Success / no outdated dependencies |
+| 1 | Outdated dependencies detected |
+| 2 | Invalid command usage |
+
+---
+
+## Upgrade command
+
+| Code | Meaning |
+|----|--------|
+| 0 | Upgrade succeeded |
+| 1 | Upgrade failed |

--- a/docs/formats/pipfile-lock.md
+++ b/docs/formats/pipfile-lock.md
@@ -1,0 +1,26 @@
+# Pipfile.lock Support
+
+depup supports read-only analysis of `Pipfile.lock`.
+
+---
+
+## What depup reads
+
+- Locked package versions
+- Dependency names
+
+---
+
+## What depup does NOT do
+
+- Modify Pipfile.lock
+- Re-lock dependencies
+
+---
+
+## Recommended workflow
+
+```bash
+depup scan --latest
+pipenv update
+```

--- a/docs/formats/poetry-lock.md
+++ b/docs/formats/poetry-lock.md
@@ -1,0 +1,28 @@
+# poetry.lock Support
+
+depup can **read** `poetry.lock` files.
+
+---
+
+## Purpose
+
+- Detect exact locked versions
+- Compare with PyPI latest versions
+- Report update impact
+
+---
+
+## Important Notes
+
+- poetry.lock is **read-only**
+- depup does NOT modify lockfiles
+- Use Poetry to regenerate locks
+
+---
+
+## Recommended workflow
+
+```bash
+depup scan --latest
+poetry update
+```

--- a/docs/formats/pyproject.md
+++ b/docs/formats/pyproject.md
@@ -1,0 +1,33 @@
+# pyproject.toml Support
+
+depup supports both modern PEP 621 and Poetry-style projects.
+
+---
+
+## PEP 621
+
+```toml
+[project]
+dependencies = [
+  "requests>=2.31.0",
+  "rich"
+]
+```
+
+---
+
+## Poetry-style
+
+```toml
+[tool.poetry.dependencies]
+python = "^3.11"
+requests = "^2.31"
+```
+
+---
+
+## Behavior
+
+* Only version parts are rewritten
+* Operators are preserved
+* Python version entries are ignored

--- a/docs/formats/requirements.md
+++ b/docs/formats/requirements.md
@@ -1,0 +1,28 @@
+# requirements.txt Support
+
+depup supports classic `requirements.txt` files.
+
+---
+
+## Supported formats
+
+```text
+requests==2.31.0
+numpy>=1.25
+pandas~=1.5
+```
+
+---
+
+## Behavior
+
+* Ignores comments and blank lines
+* Preserves version operators
+* Rewrites versions during upgrade
+
+---
+
+## Limitations
+
+* Editable installs (`-e`) are ignored
+* Complex flags are skipped

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,56 @@
 # depup Documentation
 
-Welcome to the official depup documentation.
+**depup** is a dependency upgrade advisor for Python projects.  
+It helps teams **understand**, **monitor**, and **safely upgrade** dependencies
+across files, lockfiles, and environments.
 
-Use the left sidebar to explore CLI commands, API reference, and examples.
+---
+
+## Why depup?
+
+Most Python projects struggle with:
+
+- Dependencies scattered across multiple files
+- No visibility into outdated packages
+- Risky upgrades without knowing impact
+- CI failures caused by unnoticed dependency drift
+
+depup solves this by providing:
+
+- A single view of all dependencies
+- Clear semantic version impact (patch / minor / major)
+- CI-friendly checks
+- Safe and explainable upgrade workflows
+
+---
+
+## What depup does today (v0.9.0)
+
+- Scans project dependency files and lockfiles
+- Scans installed environments
+- Fetches latest versions from PyPI
+- Classifies update impact
+- Supports JSON and Markdown reports
+- Provides CI-friendly exit codes
+
+---
+
+## Getting Started
+
+👉 Start here: [Quick Start](quickstart.md)  
+👉 Install depup: [Installation](installation.md)
+
+---
+
+## Who is depup for?
+
+- Developers maintaining Python projects
+- Teams enforcing dependency hygiene in CI
+- Open-source maintainers
+- AI-assisted developer tools (future MCP integration)
+
+---
+
+## Roadmap
+
+See the planned evolution of depup in the [Roadmap](roadmap.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,35 @@
+# Installation
+
+depup supports standard Python installation workflows.
+
+---
+
+## Using pip
+
+```bash
+pip install depup
+```
+
+---
+
+## Using uv (recommended)
+
+```bash
+uv pip install depup
+```
+
+---
+
+## Verify installation
+
+```bash
+depup --help
+```
+
+You should see the depup CLI help output.
+
+---
+
+## Python Version Support
+
+* Python 3.11+

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1,0 +1,55 @@
+# Dependency Policies
+
+depup enables teams to enforce dependency policies consistently.
+
+---
+
+## What is a dependency policy?
+
+A dependency policy defines:
+- When upgrades are allowed
+- Which update types are acceptable
+- How strictly CI enforces updates
+
+---
+
+## Common policies
+
+### Allow only patch updates
+```bash
+depup upgrade --only-patch
+```
+
+### Fail CI on any outdated dependency
+
+```bash
+depup scan --latest --check
+```
+
+### Monitor without enforcing
+
+```bash
+depup scan --latest
+```
+
+---
+
+## Recommended policy progression
+
+| Stage           | Policy              |
+| --------------- | ------------------- |
+| Early project   | Monitor only        |
+| Growing project | Enforce patch/minor |
+| Mature project  | Strict enforcement  |
+
+---
+
+## Why depup helps
+
+depup separates:
+
+* **Detection** from **execution**
+* **Policy** from **mechanics**
+
+This makes dependency management safer and auditable.
+

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,61 @@
+# Quick Start
+
+This guide shows the most common depup workflows.
+
+---
+
+## Scan project dependencies
+
+```bash
+depup scan
+```
+
+Shows all declared dependencies and where they are defined.
+
+---
+
+## Check for latest versions
+
+```bash
+depup scan --latest
+```
+
+Adds latest available versions from PyPI and update type.
+
+---
+
+## Scan installed environment
+
+```bash
+depup scan --env --latest
+```
+
+Checks packages installed in the current Python environment.
+
+---
+
+## CI-friendly check
+
+```bash
+depup scan --latest --check
+```
+
+* Exit code `0`: all dependencies up to date
+* Exit code `1`: outdated dependencies found
+
+---
+
+## Generate reports
+
+```bash
+depup scan --latest --json
+depup scan --latest --report deps.md
+```
+
+---
+
+## Upgrade dependencies (preview)
+
+```bash
+depup upgrade --dry-run
+```

--- a/docs/reports/json.md
+++ b/docs/reports/json.md
@@ -1,0 +1,65 @@
+# JSON Output
+
+depup supports structured JSON output for automation, CI pipelines,
+and integrations with other tools.
+
+---
+
+## When to use JSON output
+
+Use JSON output when:
+
+- Integrating depup into CI/CD
+- Parsing results programmatically
+- Feeding results into dashboards or agents
+- Writing custom policy checks
+
+---
+
+## Command
+
+```bash
+depup scan --latest --json
+```
+
+---
+
+## JSON Structure
+
+```json
+{
+  "dependencies": [
+    {
+      "name": "requests",
+      "current": "==2.31.0",
+      "latest": "2.32.5",
+      "update_type": "minor",
+      "source": "pyproject.toml"
+    }
+  ]
+}
+```
+
+---
+
+## Fields
+
+| Field         | Description                       |
+| ------------- | --------------------------------- |
+| `name`        | Package name                      |
+| `current`     | Declared or installed version     |
+| `latest`      | Latest version on PyPI            |
+| `update_type` | `none`, `patch`, `minor`, `major` |
+| `source`      | Origin file or environment        |
+
+---
+
+## Exit codes with JSON
+
+JSON output **does not change exit codes**.
+
+Use `--check` for CI enforcement:
+
+```bash
+depup scan --latest --json --check
+```

--- a/docs/reports/markdown.md
+++ b/docs/reports/markdown.md
@@ -1,0 +1,49 @@
+# Markdown Reports
+
+depup can generate Markdown reports suitable for:
+
+- Pull request comments
+- Release audits
+- Dependency reviews
+- Human-readable records
+
+---
+
+## Command
+
+```bash
+depup scan --latest --report deps.md
+````
+
+---
+
+## What the report contains
+
+* Scan timestamp
+* Dependency table
+* Update classification
+* Source files
+
+---
+
+## Example use cases
+
+### GitHub Pull Requests
+
+Attach dependency reports to PRs for review.
+
+### Release Audits
+
+Track dependency status at release time.
+
+### Documentation
+
+Publish dependency state alongside project docs.
+
+---
+
+## Notes
+
+* Markdown reports are **read-only**
+* They do not affect exit codes
+* They are deterministic and reproducible

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,45 @@
+# Roadmap
+
+depup follows a staged evolution toward v1.0.
+
+---
+
+## v0.9.x (Current)
+
+Focus:
+- Stability
+- Documentation
+- CI readiness
+- Broad file format support
+
+Features:
+- Dependency scanning
+- Lockfile support
+- Reports (JSON, Markdown)
+- Upgrade execution
+- Exit-code enforcement
+
+---
+
+## v1.0.0 Goals
+
+- API stability
+- CLI interface freeze
+- Predictable behavior guarantees
+- Full test coverage on core flows
+
+---
+
+## Post v1.0 (Planned)
+
+- AI-assisted upgrade analysis
+- Code change suggestions
+- Changelog summarization
+- MCP agent support
+- IDE integrations
+
+---
+
+## Guiding principle
+
+> depup prioritizes **safety, clarity, and trust** over automation speed.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,45 @@
+# Vision
+
+depup is not just a dependency updater.
+
+It is a **dependency advisor**.
+
+---
+
+## The problem depup addresses
+
+- Dependencies change faster than teams can track
+- Upgrades are risky without understanding impact
+- Automation tools often lack context
+
+---
+
+## depup’s philosophy
+
+- Explain before acting
+- Classify impact clearly
+- Keep humans in the loop
+- Enable automation responsibly
+
+---
+
+## AI and MCP direction
+
+depup is designed to integrate with:
+- AI-powered IDEs
+- Autonomous agents
+- Policy-driven automation
+
+Through:
+- Structured outputs
+- Deterministic behavior
+- Clear execution boundaries
+
+---
+
+## Long-term goal
+
+Make dependency upgrades:
+- Predictable
+- Auditable
+- Explainable

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,13 +1,68 @@
 site_name: depup Documentation
+site_description: Dependency Upgrade Advisor for Python projects
+site_author: Sai Saran Dammavalam
+repo_name: saran-damm/depup
 repo_url: https://github.com/saran-damm/depup
+site_url: https://saran-damm.github.io/depup/
+
 theme:
   name: material
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.path
+    - navigation.top
+    - content.code.copy
+  palette:
+    - scheme: default
+      primary: blue
+      accent: indigo
+    - scheme: slate
+      primary: blue
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+
+markdown_extensions:
+  - admonition
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.superfences
+  - pymdownx.details
+  - pymdownx.highlight
+
+plugins:
+  - search
 
 nav:
   - Home: index.md
-  - Installation: install.md
-  - CLI Usage: cli.md
-  - API Reference:
-      - Parser: api/parser.md
-      - Version Scanner: api/scanner.md
-      - Upgrade Executor: api/upgrade.md
+  - Installation: installation.md
+  - Quick Start: quickstart.md
+
+  - Commands:
+      - Scan: commands/scan.md
+      - Upgrade: commands/upgrade.md
+
+  - Dependency Formats:
+      - requirements.txt: formats/requirements.md
+      - pyproject.toml: formats/pyproject.md
+      - poetry.lock: formats/poetry-lock.md
+      - Pipfile.lock: formats/pipfile-lock.md
+
+  - Reports:
+      - JSON Output: reports/json.md
+      - Markdown Reports: reports/markdown.md
+
+  - CI & Automation:
+      - GitHub Actions: ci/github-actions.md
+      - Exit Codes: exit-codes.md
+      - Dependency Policies: policies.md
+
+  - Architecture:
+      - Overview: architecture/overview.md
+
+  - Project:
+      - Roadmap: roadmap.md
+      - Vision: vision.md


### PR DESCRIPTION
## Summary

This PR introduces a **complete, stable documentation foundation** for depup ahead of the v0.9.0 release.

The goal of this change is to make depup:

* Easy to understand for new users
* Trustworthy for teams and CI usage
* Clearly documented for maintainers
* Ready for future v1.0 evolution

---

## What’s included

### Documentation Structure

* Introduced a **layered documentation model**:

  * README for orientation
  * GitHub Pages (MkDocs) for detailed usage

### New Documentation Pages

* **Core**

  * Introduction & philosophy
  * Installation & quick start
* **Commands**

  * `scan` command
  * `upgrade` command
* **Dependency formats**

  * `requirements.txt`
  * `pyproject.toml`
  * `poetry.lock`
  * `Pipfile.lock`
* **Reports**

  * JSON output
  * Markdown reports
* **CI & Automation**

  * GitHub Actions integration
  * Exit codes
  * Dependency policies
* **Architecture**

  * High-level architecture overview with Mermaid diagrams
* **Project direction**

  * Roadmap
  * Vision

### Tooling & Infrastructure

* Finalized **`mkdocs.yml`**
* Added **GitHub Pages deployment workflow**
* Enabled Material for MkDocs theme
* Clean navigation and stable URLs

---

## Why this matters

* Establishes **documentation stability** before v1.0
* Improves onboarding and discoverability
* Makes depup CI-ready and enterprise-friendly
* Reduces future documentation churn

---

## Scope

* Documentation only
* No runtime or CLI behavior changes
* No breaking changes

---

## Validation

* Docs build successfully via GitHub Actions
* Local `mkdocs serve` verified
* All navigation links validated
* Mermaid diagrams render correctly